### PR TITLE
Add trade name search and layout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Medicine Viewer
+
+A lightweight web app to browse basic information about medicines stored as JSON files.
+
+## Features
+- Displays medicine data from the `Medicine/` folder.
+- Sidebar listing of available medicine files.
+- Search box to quickly filter medicines. Trade names or commercial products
+  will match their active ingredient.
+- Responsive and simple design using plain HTML, CSS and JavaScript.
+- The README is loaded and shown as the default home page.
+
+## Usage
+For best results run a simple HTTP server in the repository root and open `index.html` in your browser (for example `python3 -m http.server`). The app loads the available JSON files automatically. Click a medicine from the sidebar to view details.
+
+The search box supports trade names in addition to active ingredient names. Typing a brand such as `Prozac` will reveal the Fluoxetine entry.
+
+To add a new medicine, place a JSON file with the same structure as the provided examples in the `Medicine` folder and include its name in the `medFiles` array inside `index.html`.
+
+## License
+MIT

--- a/index.html
+++ b/index.html
@@ -6,9 +6,37 @@
   <title>Medicine Viewer</title>
   <style>
     /* --- Basic layout --- */
-    body { margin: 0; display: flex; height: 100vh; font-family: Arial, sans-serif; }
-    #sidebar { width: 200px; padding: 10px; background: #f3f3f3; overflow-y: auto; box-shadow: 2px 0 4px rgba(0,0,0,0.1); }
-    #content { flex: 1; padding: 20px; overflow-y: auto; }
+    body {
+      margin: 0;
+      display: flex;
+      height: 100vh;
+      font-family: Arial, sans-serif;
+      background: #fafafa;
+    }
+    #sidebar {
+      width: 220px;
+      padding: 10px;
+      background: #f0f0f0;
+      overflow-y: auto;
+      box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
+    }
+    #content {
+      flex: 1;
+      padding: 20px;
+      overflow-y: auto;
+      background: #fff;
+      box-shadow: inset 0 0 5px rgba(0,0,0,0.05);
+    }
+
+    /* --- Search box --- */
+    #search {
+      width: 100%;
+      padding: 6px;
+      margin-bottom: 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
 
     /* --- Buttons --- */
     .med-btn {
@@ -17,21 +45,34 @@
       margin-bottom: 6px;
       border: none;
       border-radius: 4px;
-      background: #4caf50;
+      background: #6c63ff;
       color: #fff;
       cursor: pointer;
+      transition: background 0.2s;
     }
-    .med-btn:hover { background: #3d8e41; }
+    .med-btn:hover {
+      background: #5753c9;
+    }
 
     /* --- Content section --- */
     h2 { margin-top: 0; }
-    .category { margin-bottom: 18px; }
-    .category h3 { margin: 6px 0; }
+    .category {
+      margin-bottom: 18px;
+    }
+    .category h3 {
+      margin: 6px 0;
+    }
+    ul {
+      padding-left: 20px;
+    }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
   <!-- Sidebar for medicine list -->
-  <div id="sidebar"></div>
+  <div id="sidebar">
+    <input type="text" id="search" placeholder="Search...">
+  </div>
 
   <!-- Main area for details -->
   <div id="content"><p>Select a medicine from the left side.</p></div>
@@ -48,9 +89,13 @@
     /*------------- HELPERS -------------*/
     const sidebar = document.getElementById("sidebar");
     const content = document.getElementById("content");
+    const searchInput = document.getElementById("search");
+    const medSynonyms = {}; // {medName: [list of trade names]}
 
     function initializeMedicines() {
         medFiles.forEach(makeButton);
+        searchInput.addEventListener('input', filterMedicines);
+        preloadSynonyms();
     }
 
     function cap(str) { return str.charAt(0).toUpperCase() + str.slice(1); }
@@ -59,8 +104,37 @@
       const btn = document.createElement("button");
       btn.textContent = cap(name);
       btn.className = "med-btn";
+      btn.dataset.med = name.toLowerCase();
       btn.addEventListener("click", () => loadMedicine(name));
       sidebar.appendChild(btn);
+    }
+
+    function preloadSynonyms() {
+      medFiles.forEach(name => {
+        fetch(`Medicine/${name}.json`)
+          .then(r => r.json())
+          .then(json => {
+            const key = Object.keys(json)[0];
+            const med = json[key][0];
+            const list = [];
+            ["liquid", "tablet", "other"].forEach(cat => {
+              (med[cat] || []).forEach(item => list.push(item.toLowerCase()));
+            });
+            medSynonyms[name.toLowerCase()] = list;
+          })
+          .catch(err => console.error('Error loading ' + name, err));
+      });
+    }
+
+    function filterMedicines() {
+      const term = searchInput.value.toLowerCase();
+      document.querySelectorAll('.med-btn').forEach(btn => {
+        const name = btn.dataset.med;
+        const syns = medSynonyms[name] || [];
+        const matchName = name.includes(term);
+        const matchSyn = syns.some(s => s.includes(term));
+        btn.style.display = matchName || matchSyn ? '' : 'none';
+      });
     }
 
     /*------------- LOAD & RENDER -------------*/
@@ -113,8 +187,21 @@
       });
     }
 
+    function loadReadme() {
+      fetch('README.md')
+        .then(r => r.text())
+        .then(text => {
+          content.innerHTML = marked.parse(text);
+        })
+        .catch(err => {
+          console.error('Error loading README:', err);
+          content.textContent = 'README could not be loaded.';
+        });
+    }
+
     /*------------- INIT -------------*/
-    initializeMedicines(); // Initialize with predefined list
+    initializeMedicines(); // Initialize sidebar buttons
+    loadReadme(); // Show README on startup
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix input overflow with `box-sizing: border-box`
- preload medicine files to gather trade names
- filter search results by trade names
- document search improvements in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68864cd4b054832f84c4a5161bf88921